### PR TITLE
[14.0][FIX] sale_timesheet_lock: restrict changes only for a selected fields

### DIFF
--- a/sale_timesheet_lock/__manifest__.py
+++ b/sale_timesheet_lock/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Project",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": ["sale_timesheet"],


### PR DESCRIPTION
With this bugfix when a sale order is billed, a timesheet write error is not thrown. In general, only project, task and unit amount edition is restricted.