### PR TITLE
[14.0][FIX] sale_order_line_project_task: fix missing permissions for at least project users

### DIFF
--- a/sale_order_line_project_task/__manifest__.py
+++ b/sale_order_line_project_task/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": [

--- a/sale_order_line_project_task/views/account_move_views.xml
+++ b/sale_order_line_project_task/views/account_move_views.xml
@@ -4,6 +4,7 @@
         <field name="name">account.move.form (task_id)</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
+        <field name="groups_id" eval="[(4, ref('project.group_project_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='country_code']" position="after">
                 <field name="tasks_count" invisible="1"/>

--- a/sale_order_line_project_task/views/sale_order_views.xml
+++ b/sale_order_line_project_task/views/sale_order_views.xml
@@ -4,6 +4,7 @@
         <field name="name">sale.order.form (task_id)</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="groups_id" eval="[(4, ref('project.group_project_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//tree/field[@name='name']" position="after">
                 <field name="product_type" invisible="1"/>

--- a/sale_order_line_project_task/views/stock_move_line_views.xml
+++ b/sale_order_line_project_task/views/stock_move_line_views.xml
@@ -4,6 +4,7 @@
         <field name="name">stock.move.line.tree (task_id)</field>
         <field name="model">stock.move.line</field>
         <field name="inherit_id" ref="stock.view_stock_move_line_detailed_operation_tree" />
+        <field name="groups_id" eval="[(4, ref('project.group_project_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_id']" position="after">
                 <field name="task_id" string="Task" readonly="1" attrs="{'column_invisible': [('parent.tasks_count', '=', 0)]}"/>

--- a/sale_order_line_project_task/views/stock_move_views.xml
+++ b/sale_order_line_project_task/views/stock_move_views.xml
@@ -4,6 +4,7 @@
         <field name="name">stock.move.tree (task_id)</field>
         <field name="model">stock.move</field>
         <field name="inherit_id" ref="stock.view_move_tree" />
+        <field name="groups_id" eval="[(4, ref('project.group_project_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_id']" position="after">
                 <field name="task_id" string="Task" readonly="1" optional="show" />
@@ -15,6 +16,7 @@
         <field name="name">stock.move.search (task_id)</field>
         <field name="model">stock.move</field>
         <field name="inherit_id" ref="stock.view_move_search" />
+        <field name="groups_id" eval="[(4, ref('project.group_project_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="task_id" string="Task" />

--- a/sale_order_line_project_task/views/stock_picking_views.xml
+++ b/sale_order_line_project_task/views/stock_picking_views.xml
@@ -4,6 +4,7 @@
         <field name="name">stock.picking.form (task_id)</field>
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="groups_id" eval="[(4, ref('project.group_project_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='origin']" position="after">
                 <field name="tasks_count" invisible="1"/>


### PR DESCRIPTION
With this fix, a user who accesses sales with project, and their related picking and invoices, will work even if does not belong to any `Project` security group.