### PR TITLE
[13.0][IMP] sale_order_move_menu: update the price amount total field in the tree view

### DIFF
--- a/sale_order_move_menu/__manifest__.py
+++ b/sale_order_move_menu/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.1.0",
+    "version": "13.0.1.2.0",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": ["sale_stock"],

--- a/sale_order_move_menu/i18n/es.po
+++ b/sale_order_move_menu/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-19 16:00+0000\n"
-"PO-Revision-Date: 2022-01-19 17:01+0100\n"
+"POT-Creation-Date: 2022-01-31 07:44+0000\n"
+"PO-Revision-Date: 2022-01-31 08:46+0100\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Language: es_ES\n"
 
 #. module: sale_order_move_menu
-#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__sale_price_amount_total
+#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__menu_price_amount_total
 msgid "Amount Total"
 msgstr "Importe Total"
 
@@ -47,6 +47,11 @@ msgstr "Desde"
 #: model_terms:ir.ui.view,arch_db:sale_order_move_menu.stock_move_move_menu_search
 msgid "Group By"
 msgstr "Agrupar por"
+
+#. module: sale_order_move_menu
+#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__menu_invoice_lines_count
+msgid "Menu Invoice Lines Count"
+msgstr "Menú recuento de líneas de factura"
 
 #. module: sale_order_move_menu
 #: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__sale_order
@@ -115,7 +120,7 @@ msgid "Total Quantity"
 msgstr "Cantidad total"
 
 #. module: sale_order_move_menu
-#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__sale_price_unit
+#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__menu_price_unit
 msgid "Unit Price"
 msgstr "Precio unitario"
 

--- a/sale_order_move_menu/i18n/sale_order_move_menu.pot
+++ b/sale_order_move_menu/i18n/sale_order_move_menu.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-19 16:00+0000\n"
-"PO-Revision-Date: 2022-01-19 16:00+0000\n"
+"POT-Creation-Date: 2022-01-31 07:44+0000\n"
+"PO-Revision-Date: 2022-01-31 07:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sale_order_move_menu
-#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__sale_price_amount_total
+#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__menu_price_amount_total
 msgid "Amount Total"
 msgstr ""
 
@@ -44,6 +44,11 @@ msgstr ""
 #. module: sale_order_move_menu
 #: model_terms:ir.ui.view,arch_db:sale_order_move_menu.stock_move_move_menu_search
 msgid "Group By"
+msgstr ""
+
+#. module: sale_order_move_menu
+#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__menu_invoice_lines_count
+msgid "Menu Invoice Lines Count"
 msgstr ""
 
 #. module: sale_order_move_menu
@@ -113,11 +118,11 @@ msgid "Total Quantity"
 msgstr ""
 
 #. module: sale_order_move_menu
-#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__sale_price_unit
-msgid "Unit Price"
+#: model_terms:ir.ui.view,arch_db:sale_order_move_menu.stock_move_move_menu_tree
+msgid "Unit of Measure"
 msgstr ""
 
 #. module: sale_order_move_menu
-#: model_terms:ir.ui.view,arch_db:sale_order_move_menu.stock_move_move_menu_tree
-msgid "Unit of Measure"
+#: model:ir.model.fields,field_description:sale_order_move_menu.field_stock_move__menu_price_unit
+msgid "Unit Price"
 msgstr ""

--- a/sale_order_move_menu/models/stock_move.py
+++ b/sale_order_move_menu/models/stock_move.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
 from odoo import api, fields, models
+from odoo.tools import float_compare
 
 
 class StockMove(models.Model):
@@ -10,15 +11,40 @@ class StockMove(models.Model):
     product_categ_id = fields.Many2one(related='product_id.categ_id')
     currency_id = fields.Many2one(related='sale_line_id.currency_id')
     sale_order = fields.Many2one(related='sale_line_id.order_id', store=True)
-    sale_partner_id = fields.Many2one(related='sale_order.partner_id', store=True)
-    sale_price_unit = fields.Float(related='sale_line_id.price_unit')
-    sale_price_amount_total = fields.Monetary(
-        compute="_compute_sale_price_amount_total",
+    sale_partner_id = fields.Many2one(
+        related='sale_order.partner_id',
+        store=True
+    )
+
+    menu_price_unit = fields.Float(
+        compute="_compute_menu_price_amount_total",
+        string="Unit Price",
+        store=True
+    )
+    menu_price_amount_total = fields.Monetary(
+        compute="_compute_menu_price_amount_total",
         string="Amount Total",
         store=True,
     )
+    menu_invoice_lines_count = fields.Integer(
+        compute="_compute_menu_price_amount_total",
+        store=True
+    )
 
-    @api.depends("sale_price_unit", "quantity_done")
-    def _compute_sale_price_amount_total(self):
+    @api.depends("sale_line_id.price_unit",
+                 "quantity_done",
+                 "sale_line_id.invoice_lines",
+                 "sale_line_id.invoice_lines.price_unit",
+                 "sale_line_id.invoice_lines.quantity")
+    def _compute_menu_price_amount_total(self):
+        precision = self.env["decimal.precision"].precision_get("Product Price")
         for record in self:
-            record.sale_price_amount_total = record.sale_price_unit * record.quantity_done
+            record.menu_invoice_lines_count = len(record.sale_line_id.invoice_lines)
+            prices = [invoice.price_unit for invoice in record.sale_line_id.invoice_lines]
+
+            if any(1 if float_compare(prices[0], price, precision_digits=precision) else 0 for price in prices) or record.menu_invoice_lines_count == 0:
+                record.menu_price_unit = record.sale_line_id.price_unit
+                record.menu_price_amount_total = record.menu_price_unit * record.quantity_done
+            else:
+                record.menu_price_unit = prices[0]
+                record.menu_price_amount_total = record.menu_price_unit * record.quantity_done

--- a/sale_order_move_menu/views/stock_move_views.xml
+++ b/sale_order_move_menu/views/stock_move_views.xml
@@ -35,7 +35,8 @@
         <field name="name">stock.move.tree (Sale Moves)</field>
         <field name="model">stock.move</field>
         <field name="arch" type="xml">
-            <tree default_order="date">
+            <tree default_order="date" decoration-success="menu_invoice_lines_count == 1" decoration-info="menu_invoice_lines_count == 0" decoration-muted="menu_invoice_lines_count > 1">
+                <field name="menu_invoice_lines_count" invisible="1"/>
                 <field name="date"/>
                 <field name="reference"/>
                 <field name="sale_line_id" invisible="1"/>
@@ -48,9 +49,8 @@
                 <field name="quantity_done" string="Quantity" sum="Total Quantity"/>
                 <field name="product_uom" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
                 <field name="currency_id" invisible="1"/>
-                <field name="sale_price_unit"/>
-                <field name="sale_line_id" invisible="1"/>
-                <field name="sale_price_amount_total" widget="monetary"  sum="Total Amount"/>
+                <field name="menu_price_unit"/>
+                <field name="menu_price_amount_total" widget="monetary"  sum="Total Amount"/>
                 <field name="state" invisible="1"/>
             </tree>
         </field>


### PR DESCRIPTION
Update the price amount total field in the tree view depending on whether the order line is related to none, one or more invoices
In the case of:
  - One invoice -> invoice price -> color in green table
  - No invoice -> order price -> color in blue table
  - More than one invoice -> order price -> color in grey table
  
![imagen](https://user-images.githubusercontent.com/22427989/151761041-8c13fab9-d1f3-4550-a1e1-200edf51e536.png)


