### PR TITLE
[13.0][FIX] sale_order_line_deliv_move_manual: show only delivered dest qty for moves linked to sale lines

### DIFF
--- a/sale_order_line_deliv_move_manual/__manifest__.py
+++ b/sale_order_line_deliv_move_manual/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": ["sale_stock"],

--- a/sale_order_line_deliv_move_manual/views/stock_picking_views.xml
+++ b/sale_order_line_deliv_move_manual/views/stock_picking_views.xml
@@ -7,6 +7,12 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <xpath
+                expr="//field[@name='move_ids_without_package']"
+                position="before"
+            >
+                <field name="sale_id" invisible="1"/>
+            </xpath>
+            <xpath
                 expr="//field[@name='move_ids_without_package']//tree//field[@name='quantity_done']"
                 position="after"
             >
@@ -15,6 +21,7 @@
                     name="qty_delivered_dest" 
                     string="Dest."
                     attrs="{
+                        'column_invisible': [('parent.sale_id', '=', False)],
                         'readonly': [('product_invoice_policy', '!=', 'stock_move_dest')],
                     }"                    
                     optional="show"
@@ -25,10 +32,15 @@
                 position="after"
             >
                 <field name="product_invoice_policy" invisible="1"/>
+                <field name="sale_line_id" invisible="1"/>
                 <field
                     name="qty_delivered_dest"
                     attrs="{
-                        'invisible': [('product_invoice_policy', '!=', 'stock_move_dest')],
+                        'invisible': [
+                            '|',
+                            ('product_invoice_policy', '!=', 'stock_move_dest'),
+                            ('sale_line_id', '=', False),
+                        ],
                     }"
                 />
             </xpath>


### PR DESCRIPTION
With this fix, only OUT pickings (and IN return) should show the new Destination quantity value on stock moves 