### PR TITLE
[13.0][IMP] sale_order_line_deliv_move_manual: new has pending destination quantities filter

### DIFF
--- a/sale_order_line_deliv_move_manual/__manifest__.py
+++ b/sale_order_line_deliv_move_manual/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.1",
+    "version": "13.0.1.1.0",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": ["sale_stock"],

--- a/sale_order_line_deliv_move_manual/i18n/es.po
+++ b/sale_order_line_deliv_move_manual/i18n/es.po
@@ -6,14 +6,27 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-21 16:27+0000\n"
-"PO-Revision-Date: 2022-01-21 16:27+0000\n"
+"POT-Creation-Date: 2022-02-17 15:37+0000\n"
+"PO-Revision-Date: 2022-02-17 15:37+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: sale_order_line_deliv_move_manual
+#: model:ir.model.fields,help:sale_order_line_deliv_move_manual.field_sale_order__has_pend_qty_delivered_dest
+msgid ""
+"\n"
+"        Indicates if any done stock move linked to this order has\n"
+"        destination delivered quantity not filled yet\n"
+"        "
+msgstr ""
+"\n"
+"        Indica si hay algún movimiento de stock hecho y enlazado con este pedido\n"
+"        que tenga sin cubrir la cantidad en destino, cuando procede\n"
+"        "
 
 #. module: sale_order_line_deliv_move_manual
 #: model:ir.model.fields,help:sale_order_line_deliv_move_manual.field_sale_order_line__qty_delivered_dest
@@ -44,6 +57,16 @@ msgid "Destination Delivered Quantity"
 msgstr "Cantidad entregada en destino"
 
 #. module: sale_order_line_deliv_move_manual
+#: model:ir.model.fields,field_description:sale_order_line_deliv_move_manual.field_sale_order__has_pend_qty_delivered_dest
+msgid "Has Pending Destination Delivered Quantity"
+msgstr ""
+
+#. module: sale_order_line_deliv_move_manual
+#: model_terms:ir.ui.view,arch_db:sale_order_line_deliv_move_manual.sale_order_view_search_inherit_sale
+msgid "Has Pending Destination Quantities"
+msgstr "Cantidades en destino pendientes"
+
+#. module: sale_order_line_deliv_move_manual
 #: model:ir.model.fields,field_description:sale_order_line_deliv_move_manual.field_product_product__invoice_policy
 #: model:ir.model.fields,field_description:sale_order_line_deliv_move_manual.field_product_template__invoice_policy
 #: model:ir.model.fields,field_description:sale_order_line_deliv_move_manual.field_sale_order_line__product_invoice_policy
@@ -72,6 +95,11 @@ msgstr ""
 #: model:ir.model,name:sale_order_line_deliv_move_manual.model_product_template
 msgid "Product Template"
 msgstr "Plantilla de producto"
+
+#. module: sale_order_line_deliv_move_manual
+#: model:ir.model,name:sale_order_line_deliv_move_manual.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
 
 #. module: sale_order_line_deliv_move_manual
 #: model:ir.model,name:sale_order_line_deliv_move_manual.model_sale_order_line

--- a/sale_order_line_deliv_move_manual/i18n/sale_order_line_deliv_move_manual.pot
+++ b/sale_order_line_deliv_move_manual/i18n/sale_order_line_deliv_move_manual.pot
@@ -6,14 +6,23 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-21 16:26+0000\n"
-"PO-Revision-Date: 2022-01-21 16:26+0000\n"
+"POT-Creation-Date: 2022-02-17 15:35+0000\n"
+"PO-Revision-Date: 2022-02-17 15:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: sale_order_line_deliv_move_manual
+#: model:ir.model.fields,help:sale_order_line_deliv_move_manual.field_sale_order__has_pend_qty_delivered_dest
+msgid ""
+"\n"
+"        Indicates if any done stock move linked to this order has\n"
+"        destination delivered quantity not filled yet\n"
+"        "
+msgstr ""
 
 #. module: sale_order_line_deliv_move_manual
 #: model:ir.model.fields,help:sale_order_line_deliv_move_manual.field_sale_order_line__qty_delivered_dest
@@ -36,6 +45,16 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_order_line_deliv_move_manual.field_sale_order_line__qty_delivered_dest
 #: model:ir.model.fields,field_description:sale_order_line_deliv_move_manual.field_stock_move__qty_delivered_dest
 msgid "Destination Delivered Quantity"
+msgstr ""
+
+#. module: sale_order_line_deliv_move_manual
+#: model:ir.model.fields,field_description:sale_order_line_deliv_move_manual.field_sale_order__has_pend_qty_delivered_dest
+msgid "Has Pending Destination Delivered Quantity"
+msgstr ""
+
+#. module: sale_order_line_deliv_move_manual
+#: model_terms:ir.ui.view,arch_db:sale_order_line_deliv_move_manual.sale_order_view_search_inherit_sale
+msgid "Has Pending Destination Quantities"
 msgstr ""
 
 #. module: sale_order_line_deliv_move_manual
@@ -64,6 +83,11 @@ msgstr ""
 #. module: sale_order_line_deliv_move_manual
 #: model:ir.model,name:sale_order_line_deliv_move_manual.model_product_template
 msgid "Product Template"
+msgstr ""
+
+#. module: sale_order_line_deliv_move_manual
+#: model:ir.model,name:sale_order_line_deliv_move_manual.model_sale_order
+msgid "Sales Order"
 msgstr ""
 
 #. module: sale_order_line_deliv_move_manual

--- a/sale_order_line_deliv_move_manual/models/__init__.py
+++ b/sale_order_line_deliv_move_manual/models/__init__.py
@@ -1,3 +1,4 @@
 from . import product_template
+from . import sale_order
 from . import sale_order_line
 from . import stock_move

--- a/sale_order_line_deliv_move_manual/models/sale_order.py
+++ b/sale_order_line_deliv_move_manual/models/sale_order.py
@@ -1,0 +1,39 @@
+# © 2022 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import api, fields, models
+from odoo.tools import float_is_zero
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    has_pend_qty_delivered_dest = fields.Boolean(
+        string="Has Pending Destination Delivered Quantity",
+        compute="_compute_has_pend_qty_delivered_dest",
+        store=True,
+        help="""
+        Indicates if any done stock move linked to this order has
+        destination delivered quantity not filled yet
+        """,
+    )
+
+    @api.depends(
+        "picking_ids.move_lines.state",
+        "picking_ids.move_lines.qty_delivered_dest",
+    )
+    def _compute_has_pend_qty_delivered_dest(self):
+        for order in self:
+            moves_done = order.picking_ids.move_lines.filtered(
+                lambda x: x.state == "done"
+                and x.product_id.invoice_policy == "stock_move_dest"
+            )
+            if moves_done:
+                order.has_pend_qty_delivered_dest = any(
+                    float_is_zero(
+                        move.qty_delivered_dest,
+                        precision_rounding=move.product_id.uom_id.rounding
+                    ) for move in moves_done
+                )
+            else:
+                order.has_pend_qty_delivered_dest = False

--- a/sale_order_line_deliv_move_manual/views/sale_order_views.xml
+++ b/sale_order_line_deliv_move_manual/views/sale_order_views.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="view_order_tree" model="ir.ui.view">
+        <field name="name">
+            sale.order.tree (in sale_order_line_deliv_move_manual)
+        </field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="attributes">
+                <attribute name="decoration-danger">
+                    has_pend_qty_delivered_dest==True
+                </attribute>
+            </xpath>
+            <xpath expr="//tree" position="inside">
+                <field name="has_pend_qty_delivered_dest" invisible="1"/>
+            </xpath>
+        </field>
+    </record>
 
     <record id="view_order_form" model="ir.ui.view">
         <field name="name">sale.order.form (in sale_order_line_deliv_move_manual)</field>
@@ -44,6 +61,24 @@
                     optional="show"
                 />
             </xpath>
+        </field>
+    </record>
+
+    <record id="sale_order_view_search_inherit_sale" model="ir.ui.view">
+        <field name="name">
+            sale.order.search.inherit.sale (in sale_order_line_deliv_move_manual)
+        </field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.sale_order_view_search_inherit_sale" />
+        <field name="arch" type="xml">
+            <filter name="my_sale_orders_filter" position="after">
+                <separator/>
+                <filter
+                    name="has_pend_qty_delivered_dest_filter"
+                    string="Has Pending Destination Quantities"
+                    domain="[('has_pend_qty_delivered_dest','=',True)]"
+                />
+            </filter>
         </field>
     </record>
 


### PR DESCRIPTION
It's possible to know for every sale order if has any pending destination quantity to be filled, for its done stock moves. This addon adds a useful filter for getting those sale orders