### PR TITLE
[13.0][FIX] sale_order_move_menu: users with Sales limited permissions restrictions

### DIFF
--- a/sale_order_move_menu/__manifest__.py
+++ b/sale_order_move_menu/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.0.1",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": ["sale_stock"],

--- a/sale_order_move_menu/models/stock_move.py
+++ b/sale_order_move_menu/models/stock_move.py
@@ -1,7 +1,7 @@
 # © 2022 Solvos Consultoría Informática (<http://www.solvos.es>)
 # License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockMove(models.Model):
@@ -14,3 +14,36 @@ class StockMove(models.Model):
         store=True
     )
     sale_user_id = fields.Many2one(related="sale_line_id.order_id.user_id")
+
+    @api.model
+    def action_sale_moves(self):
+        """
+        Modifies original sale stock move action depending on Sales role
+        of the logged user
+        """
+        # Alternative development: making our own action from scatch, like
+        #  https://github.com/odoo/odoo/blob/13.0/addons/stock/models/stock_quant.py#L622
+        # The selected strategy allow us to define action in XML file,
+        #  but has the problem of the needed "fake zero results domain" in
+        #  order to prevent "F5" pages reload, that should only use the
+        #  original action definition
+        action = self.env.ref(
+            "sale_order_move_menu.action_stock_move_move_menu"
+        )
+        result = action.read()[0]
+        # Default (fake) domain is replaced with the right one
+        domain_str = "('sale_line_id','!=',False), ('state','=','done')"
+        if not self._check_sale_all_permissions(self.env.user):
+            domain_str += ", ('sale_user_id','=',%d)" % self.env.user.id
+        result["domain"] = "[%s]" % domain_str
+
+        return result
+
+    @api.model
+    def _check_sale_all_permissions(self, user):
+        """
+        Inheritable method for permissions check depending on the user
+        This method should allow e.g. OCA sales_team_security inheritance,
+        which add a new hierarchy grouping for Sales Teams
+        """
+        return user.has_group("sales_team.group_sale_salesman_all_leads")

--- a/sale_order_move_menu/views/sale_order_views.xml
+++ b/sale_order_move_menu/views/sale_order_views.xml
@@ -10,17 +10,26 @@
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'tree', 'view_id': ref('stock_move_move_menu_tree')}),
             (0, 0, {'view_mode': 'form', 'view_id': ref('stock.view_move_form')})]"/>
-        <field name="domain">[('sale_line_id','!=', False), ('state','=', 'done')]</field>
-        <!-- <field name="domain">['|', ('location_id.usage','=', 'customer'), ('location_dest_id.usage','=', 'customer'), ('state','=', 'done')]</field> -->
+        <!-- Default access is forbidden, this action shouldn't be directly accessed -->
+        <field name="domain">[('state','=','fake')]</field>
         <field name="context">{
             "search_default_filter_date": 1,
         }</field>
     </record>
 
+    <record model="ir.actions.server" id="action_stock_move_move_menu_srv">
+        <field name="name">Sale Moves</field>
+        <field name="model_id" ref="model_stock_move"/>
+        <field name="state">code</field>
+        <field name="code">
+            action = model.action_sale_moves()
+        </field>
+    </record>
+
     <menuitem 
         id="menu_sale_order_sale_moves"
         name="Sale Moves" 
-        action="action_stock_move_move_menu"
+        action="action_stock_move_move_menu_srv"
         parent="sale.product_menu_catalog"
         sequence="3"
         groups="stock.group_stock_user"


### PR DESCRIPTION
With this bugfix users with "User: Own Documents Only" Sales group can only access (and export) those stock moves linked to their own documents. Before this bugfix, they could see every move.

@ChristianSantamaria @lmiguens-solvos already installed in latest Test environment database. Could you test it? Maybe you'll need to log out and log in, because a cached structure (the action linked to Sales Move Menu) has been modified.