### PR TITLE
[13.0][FIX] sale_order_move_menu_spil: missing dependencies

### DIFF
--- a/sale_order_move_menu_spil/__manifest__.py
+++ b/sale_order_move_menu_spil/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.0.1",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": [

--- a/sale_order_move_menu_spil/migrations/13.0.2.0.1/post-migration.py
+++ b/sale_order_move_menu_spil/migrations/13.0.2.0.1/post-migration.py
@@ -1,0 +1,14 @@
+# © 2022 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License AGPL-3.0 (https://www.gnu.org/licenses/agpl-3.0.html)
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        sale_move_ids = env['stock.move'].search([
+            ('sale_line_id', '!=', False),
+            ('state', '=', 'done')
+        ])
+        sale_move_ids._compute_sale_move_menu()

--- a/sale_order_move_menu_spil/models/stock_move.py
+++ b/sale_order_move_menu_spil/models/stock_move.py
@@ -45,7 +45,7 @@ class StockMove(models.Model):
         store=True
     )
 
-    @api.depends("state", "sale_line_id.price_unit", "invoice_line_ids.move_id.state")
+    @api.depends("state", "sale_line_id.price_unit", "invoice_line_ids.move_id.state", "invoice_line_ids.price_unit", "quantity_done")
     def _compute_sale_move_menu(self):
         precision = self.env["decimal.precision"].precision_get("Product Price")
         for record in self:


### PR DESCRIPTION
Add invoice_line_ids.price_unit and quantity_done dependencies, update all stock move [('sale_line_id', '!=', False), ('state', '=', 'done')] with post-migration system

Need to install it in test, I will keep the status informed...