### PR TITLE
[14.0][IMP] sale_order_type_note_template: prevent order note propagation to invoice

### DIFF
--- a/sale_order_type_note_template/README.rst
+++ b/sale_order_type_note_template/README.rst
@@ -22,6 +22,10 @@ Sale Order Type - Default Terms and conditions Template
 For the selected order types, by default a Terms and conditions Template
 can be selected.
 
+In addition, the selected Terms and Conditions text is not propagated to
+the invoice when confirmed, which is HTML based and breaks invoice note
+container (text based).
+
 **Table of contents**
 
 .. contents::

--- a/sale_order_type_note_template/__manifest__.py
+++ b/sale_order_type_note_template/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "category": "Sales/Sales",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": [

--- a/sale_order_type_note_template/models/sale_order.py
+++ b/sale_order_type_note_template/models/sale_order.py
@@ -12,3 +12,12 @@ class SaleOrder(models.Model):
         if self.type_id.terms_template_id:
             self.terms_template_id = self.type_id.terms_template_id
             self._onchange_terms_template_id()
+
+    def _prepare_invoice(self):
+        """
+        Prevent HTML order Terms & Conditions to the invoice, which is simply
+        text based
+        """
+        invoice_values = super()._prepare_invoice()
+        invoice_values.pop("narration")
+        return invoice_values

--- a/sale_order_type_note_template/readme/DESCRIPTION.rst
+++ b/sale_order_type_note_template/readme/DESCRIPTION.rst
@@ -1,2 +1,6 @@
 For the selected order types, by default a Terms and conditions Template
 can be selected.
+
+In addition, the selected Terms and Conditions text is not propagated to
+the invoice when confirmed, which is HTML based and breaks invoice note
+container (text based).

--- a/sale_order_type_note_template/static/description/index.html
+++ b/sale_order_type_note_template/static/description/index.html
@@ -370,6 +370,9 @@ ul.auto-toc {
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/solvosci/slv-sale/tree/14.0/sale_order_type_note_template"><img alt="solvosci/slv-sale" src="https://img.shields.io/badge/github-solvosci%2Fslv--sale-lightgray.png?logo=github" /></a></p>
 <p>For the selected order types, by default a Terms and conditions Template
 can be selected.</p>
+<p>In addition, the selected Terms and Conditions text is not propagated to
+the invoice when confirmed, which is HTML based and breaks invoice note
+container (text based).</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">


### PR DESCRIPTION
With this improvement the selected Terms and Conditions text is not propagated to the invoice when confirmed, which is HTML based and breaks invoice note container (text based).

cc @ChristianSantamaria 