### PR TITLE
[14.0][FIX] fcd_sale_order: move.lines are not assigned to picking

### DIFF
--- a/fcd_sale_order/__manifest__.py
+++ b/fcd_sale_order/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "14.0.1.0.1",
+    "version": "14.0.1.0.2",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": [

--- a/fcd_sale_order/__manifest__.py
+++ b/fcd_sale_order/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.0.3",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": [

--- a/fcd_sale_order/models/stock_move.py
+++ b/fcd_sale_order/models/stock_move.py
@@ -13,6 +13,7 @@ class StockMove(models.Model):
         elif self.sale_line_id:
             values = {
                 'move_id': self.id,
+                'picking_id': self.picking_id.id,
                 'company_id': self.company_id.id,
                 'product_id': self.product_id.id,
                 'product_uom_id': self.product_uom.id,

--- a/fcd_sale_order/wizards/fcd_stock_quant.py
+++ b/fcd_sale_order/wizards/fcd_stock_quant.py
@@ -44,6 +44,7 @@ class FCDStockQuant(models.TransientModel):
         # Else open wizard from stock.move.line
         else:
             self.stock_move_line_id.lot_id = self.lot_id.id
+            self.stock_move_line_id.secondary_uom_qty = self.stock_move_line_id.move_id.secondary_uom_qty
             self.stock_move_line_id.qty_done = self.stock_move_line_id.move_id.product_uom_qty
             self.stock_move_line_id.location_id = self.location_id.id
             return self.stock_move_line_id.move_id.action_show_details()


### PR DESCRIPTION
When printing picking report, no lines appear because the move lines were not directly related to picking