### PR TITLE
[15.0][IMP] sale_order_client_order_ref_mandatory: added to Sales Order tree view

### DIFF
--- a/sale_order_client_order_ref_mandatory/__manifest__.py
+++ b/sale_order_client_order_ref_mandatory/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.1.0",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": ["sale"],

--- a/sale_order_client_order_ref_mandatory/views/sale_order_view.xml
+++ b/sale_order_client_order_ref_mandatory/views/sale_order_view.xml
@@ -18,12 +18,12 @@
         </field>
     </record>
 
-    <record id="view_sale_order_search_inherit" model="ir.ui.view">
-        <field name="name">sale.order.search (client_order_ref)</field>
+    <record id="view_sales_order_filter" model="ir.ui.view">
+        <field name="name">sale.order.list.select (in sale_order_client_order_ref_mandatory)</field>
         <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.sale_order_view_search_inherit_quotation" />
+        <field name="inherit_id" ref="sale.view_sales_order_filter" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='campaign_id']" position="after">            
+            <xpath expr="//field[@name='partner_id']" position="after">            
                 <field name="client_order_ref"/>
             </xpath>
         </field>
@@ -39,5 +39,14 @@
             </xpath>
         </field>
     </record>
-
+    <record id="view_order_tree" model="ir.ui.view">
+        <field name="name">sale.order.tree order (in sale_order_client_order_ref_mandatory)</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_id']" position="after">            
+                <field name="client_order_ref" optional="show"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
At least in v15, `client_order_ref` only is shown in Quotations tree view. With this improvement is also shown in Sales Order one.
Search inheritance is also improved in order to be reused in both Sales Order views

cc @ChristianSantamaria 