### PR TITLE
[14.0][IMP] fcd_sale_order: new fcd_document_id and fcd_document_line_id fields in stock.move.line

### DIFF
--- a/fcd_sale_order/__manifest__.py
+++ b/fcd_sale_order/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "14.0.1.0.4",
+    "version": "14.0.1.1.0",
     "category": "Sale",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": [

--- a/fcd_sale_order/i18n/es.po
+++ b/fcd_sale_order/i18n/es.po
@@ -6,16 +6,33 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-28 08:27+0000\n"
-"PO-Revision-Date: 2022-11-28 09:28+0100\n"
+"POT-Creation-Date: 2023-07-05 08:02+0000\n"
+"PO-Revision-Date: 2023-07-05 10:04+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: es_ES\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 "X-Generator: Poedit 3.1.1\n"
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,help:fcd_sale_order.field_sale_order_line__lot_location_id
+msgid ""
+"\n"
+"        When a lot is selected from Stock Quant wizard, this field is "
+"filled\n"
+"        with source location, that can be used in stock move line "
+"completion\n"
+"        process\n"
+"        "
+msgstr ""
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__product_stock_secondary_uom_id
+msgid "2nd unit"
+msgstr ""
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__available_quantity
@@ -54,11 +71,22 @@ msgstr "Moneda"
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__display_name
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order__display_name
 #: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order_line__display_name
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move__display_name
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line__display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line__fcd_document_id
+msgid "Fcd Document"
+msgstr "Lote de proveedor"
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line__fcd_document_line_id
+msgid "Fcd Document Line"
+msgstr "Lote de pesca"
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line__fcd_origin_lot_id
@@ -67,11 +95,17 @@ msgstr "Lote original FCD"
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__id
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order__id
 #: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order_line__id
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move__id
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line__id
 msgid "ID"
 msgstr "Id."
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order__fcd_import
+msgid "Import"
+msgstr ""
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__inventory_quantity
@@ -80,6 +114,7 @@ msgstr "Cantidad a mano"
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard____last_update
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order____last_update
 #: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order_line____last_update
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move____last_update
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line____last_update
@@ -102,6 +137,11 @@ msgid "Location"
 msgstr "Ubicación"
 
 #. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order_line__lot_location_id
+msgid "Lot Location"
+msgstr ""
+
+#. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__lot_id
 msgid "Lot/Serial Number"
 msgstr "Lote/Nº de serie"
@@ -122,7 +162,7 @@ msgstr ""
 
 #. module: fcd_sale_order
 #: model_terms:ir.ui.view,arch_db:fcd_sale_order.view_sale_order_form_inherit
-#: model_terms:ir.ui.view,arch_db:fcd_sale_order.view_stock_move_line_operation_tree
+#: model_terms:ir.ui.view,arch_db:fcd_sale_order.view_stock_move_line_operation_tree_sq
 msgid "Open Stock Quant"
 msgstr "Abrir stock a mano"
 
@@ -161,6 +201,16 @@ msgid "Qty"
 msgstr "Cant."
 
 #. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__inventory_quantity_secondary_uom
+msgid "Quant in 2nd unit"
+msgstr ""
+
+#. module: fcd_sale_order
+#: model_terms:ir.ui.view,arch_db:fcd_sale_order.view_sale_order_form_inherit
+msgid "Remove selected lot"
+msgstr ""
+
+#. module: fcd_sale_order
 #: model_terms:ir.ui.view,arch_db:fcd_sale_order.stock_move_line_sale_view_search
 msgid "Sale Date"
 msgstr "Fecha Venta"
@@ -183,14 +233,14 @@ msgid "Sales Margin by Move"
 msgstr "Margen de ventas por operación"
 
 #. module: fcd_sale_order
+#: model:ir.model,name:fcd_sale_order.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de Ventas"
+
+#. module: fcd_sale_order
 #: model:ir.model,name:fcd_sale_order.model_sale_order_line
 msgid "Sales Order Line"
 msgstr "Línea de pedido de venta"
-
-#. module: fcd_sale_order
-#: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__secondary_uom_ids
-msgid "Secondary Uom"
-msgstr "Cantidad de cajas"
 
 #. module: fcd_sale_order
 #: model:ir.model,name:fcd_sale_order.model_stock_move
@@ -219,8 +269,3 @@ msgstr "Valor"
 #: model:ir.model,name:fcd_sale_order.model_fcd_stock_quant_wizard
 msgid "fcd.stock.quant.wizard"
 msgstr ""
-
-#. module: sale_order_action_confirm_multi
-#: model:ir.actions.server,name:sale_order_action_confirm_multi.action_sale_order_confirm_multi
-msgid "Confirm and Validate"
-msgstr "Confirmar y validar"

--- a/fcd_sale_order/i18n/fcd_sale_order.pot
+++ b/fcd_sale_order/i18n/fcd_sale_order.pot
@@ -6,14 +6,29 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-28 08:27+0000\n"
-"PO-Revision-Date: 2022-11-28 08:27+0000\n"
+"POT-Creation-Date: 2023-07-05 08:01+0000\n"
+"PO-Revision-Date: 2023-07-05 08:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,help:fcd_sale_order.field_sale_order_line__lot_location_id
+msgid ""
+"\n"
+"        When a lot is selected from Stock Quant wizard, this field is filled\n"
+"        with source location, that can be used in stock move line completion\n"
+"        process\n"
+"        "
+msgstr ""
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__product_stock_secondary_uom_id
+msgid "2nd unit"
+msgstr ""
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__available_quantity
@@ -50,10 +65,21 @@ msgstr ""
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__display_name
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order__display_name
 #: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order_line__display_name
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move__display_name
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line__fcd_document_id
+msgid "Fcd Document"
+msgstr ""
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line__fcd_document_line_id
+msgid "Fcd Document Line"
 msgstr ""
 
 #. module: fcd_sale_order
@@ -63,10 +89,16 @@ msgstr ""
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__id
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order__id
 #: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order_line__id
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move__id
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line__id
 msgid "ID"
+msgstr ""
+
+#. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order__fcd_import
+msgid "Import"
 msgstr ""
 
 #. module: fcd_sale_order
@@ -76,6 +108,7 @@ msgstr ""
 
 #. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard____last_update
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order____last_update
 #: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order_line____last_update
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move____last_update
 #: model:ir.model.fields,field_description:fcd_sale_order.field_stock_move_line____last_update
@@ -98,6 +131,11 @@ msgid "Location"
 msgstr ""
 
 #. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_sale_order_line__lot_location_id
+msgid "Lot Location"
+msgstr ""
+
+#. module: fcd_sale_order
 #: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__lot_id
 msgid "Lot/Serial Number"
 msgstr ""
@@ -116,7 +154,7 @@ msgstr ""
 
 #. module: fcd_sale_order
 #: model_terms:ir.ui.view,arch_db:fcd_sale_order.view_sale_order_form_inherit
-#: model_terms:ir.ui.view,arch_db:fcd_sale_order.view_stock_move_line_operation_tree
+#: model_terms:ir.ui.view,arch_db:fcd_sale_order.view_stock_move_line_operation_tree_sq
 msgid "Open Stock Quant"
 msgstr ""
 
@@ -153,6 +191,16 @@ msgid "Qty"
 msgstr ""
 
 #. module: fcd_sale_order
+#: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__inventory_quantity_secondary_uom
+msgid "Quant in 2nd unit"
+msgstr ""
+
+#. module: fcd_sale_order
+#: model_terms:ir.ui.view,arch_db:fcd_sale_order.view_sale_order_form_inherit
+msgid "Remove selected lot"
+msgstr ""
+
+#. module: fcd_sale_order
 #: model_terms:ir.ui.view,arch_db:fcd_sale_order.stock_move_line_sale_view_search
 msgid "Sale Date"
 msgstr ""
@@ -175,13 +223,13 @@ msgid "Sales Margin by Move"
 msgstr ""
 
 #. module: fcd_sale_order
-#: model:ir.model,name:fcd_sale_order.model_sale_order_line
-msgid "Sales Order Line"
+#: model:ir.model,name:fcd_sale_order.model_sale_order
+msgid "Sales Order"
 msgstr ""
 
 #. module: fcd_sale_order
-#: model:ir.model.fields,field_description:fcd_sale_order.field_fcd_stock_quant_wizard__secondary_uom_ids
-msgid "Secondary Uom"
+#: model:ir.model,name:fcd_sale_order.model_sale_order_line
+msgid "Sales Order Line"
 msgstr ""
 
 #. module: fcd_sale_order
@@ -210,9 +258,4 @@ msgstr ""
 #. module: fcd_sale_order
 #: model:ir.model,name:fcd_sale_order.model_fcd_stock_quant_wizard
 msgid "fcd.stock.quant.wizard"
-msgstr ""
-
-#. module: sale_order_action_confirm_multi
-#: model:ir.actions.server,name:sale_order_action_confirm_multi.action_sale_order_confirm_multi
-msgid "Confirm and Validate"
 msgstr ""

--- a/fcd_sale_order/migrations/14.0.1.1.0/pre-migration.py
+++ b/fcd_sale_order/migrations/14.0.1.1.0/pre-migration.py
@@ -1,0 +1,34 @@
+# © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+import logging
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+    logger = logging.getLogger(__name__)
+    logger.info(
+        "Creating columns: stock_move_line (fcd_document_line_id)."
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+            ALTER TABLE stock_move_line
+            ADD COLUMN IF NOT EXISTS fcd_document_line_id INT
+        """
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE stock_move_line
+            SET fcd_document_line_id = COALESCE(spl1.fcd_document_line_id, spl2.fcd_document_line_id)
+            FROM stock_move_line sml
+            LEFT JOIN stock_production_lot spl1 ON spl1.id = sml.lot_id
+            LEFT JOIN stock_production_lot spl2 ON spl2.id = spl1.fcd_origin_lot_id
+            WHERE stock_move_line.id = sml.id;
+        """
+    )
+    logger.info("Successfully updated stock_move_line table")

--- a/fcd_sale_order/models/stock_move_line.py
+++ b/fcd_sale_order/models/stock_move_line.py
@@ -43,6 +43,8 @@ class StockMoveLine(models.Model):
         currency_field="sale_currency_id",
         store=True,
     )
+    fcd_document_id = fields.Many2one(related='fcd_document_line_id.fcd_document_id')
+    fcd_document_line_id = fields.Many2one('fcd.document.line', compute='_compute_fcd_document_line_id', store=True)
 
     @api.depends(
         "product_uom_id",
@@ -81,6 +83,16 @@ class StockMoveLine(models.Model):
             "sale_price_kg": 0.0,
             "sale_margin": 0.0,
         })
+
+    @api.depends('lot_id.fcd_document_line_id', 'lot_id.fcd_origin_lot_id.fcd_document_line_id')
+    def _compute_fcd_document_line_id(self):
+        for record in self:
+            if record.lot_id.fcd_document_line_id:
+                record.fcd_document_line_id = record.lot_id.fcd_document_line_id
+            elif record.lot_id.fcd_origin_lot_id.fcd_document_line_id:
+                record.fcd_document_line_id = record.lot_id.fcd_origin_lot_id.fcd_document_line_id
+            else:
+                record.fcd_document_line_id = False
 
     @api.model
     def read_group(

--- a/fcd_sale_order/views/stock_move_line_views.xml
+++ b/fcd_sale_order/views/stock_move_line_views.xml
@@ -89,7 +89,19 @@
                 <field name="sale_margin" type="measure" widget="monetary"/>
             </pivot>
         </field>
-    </record>    
+    </record>
+    <!-- Product moves -->
+    <record id="view_move_line_form" model="ir.ui.view">
+        <field name="name">stock.move.line (in fcd_sale_order)</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_move_line_form" />
+        <field name="groups_id" eval="[(4, ref('fcd.group_fcd_user'))]" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='lot_name']" position="after">
+                <field name="fcd_document_id" />
+            </xpath>
+        </field>
+    </record>
     <record id="action_stock_move_line_sale_pivot" model="ir.actions.act_window">
         <field name="name">Sales Margin by Move</field>
         <field name="res_model">stock.move.line</field>


### PR DESCRIPTION
Adds two new fields:
 - fcd_document_id related="fcd_document_line_id.fcd_document_id"
 - fcd_document_line_id = compute storable, create and update in pre-migration