### PR TITLE
[17.0][FIX] sale_order_secondary_unit_stock_catalog: proper update product secondary stock fields

### DIFF
--- a/sale_order_secondary_unit_stock_catalog/__manifest__.py
+++ b/sale_order_secondary_unit_stock_catalog/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "category": "Sales/Sales",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": ["sale_order_secondary_unit", "stock"],

--- a/sale_order_secondary_unit_stock_catalog/models/product_product.py
+++ b/sale_order_secondary_unit_stock_catalog/models/product_product.py
@@ -55,13 +55,13 @@ class Product(models.Model):
                 ssu_qty_available = (
                     product.qty_available / product.sale_secondary_uom_id.factor
                 )
-                product.write({
+                product.update({
                     "sale_secondary_unit_qty_available": ssu_qty_available,
                     "has_sale_secondary_unit_qty_available": not float_is_zero(
                         ssu_qty_available, precision_digits=dp
                     ),
                 })
-        (self - products_ssu).write({
+        (self - products_ssu).update({
             "sale_secondary_unit_qty_available": 0.0,
             "has_sale_secondary_unit_qty_available": False,
         })


### PR DESCRIPTION
Before this fix, an error was raised when a user with insufficient permissions want to access Sales catalog. This fixes it.