### PR TITLE
[17.0][FIX] sale_order_partner_invoice_period: Warning in res_config_setting.py field

### DIFF
--- a/sale_order_partner_invoice_period/__manifest__.py
+++ b/sale_order_partner_invoice_period/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": """ Adds selection of period to invoice direction """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "17.0.1.3.0",
+    "version": "17.0.1.3.1",
     "category": "Sales/Sales",
     "website": "https://github.com/solvosci/slv-sale",
     "depends": [

--- a/sale_order_partner_invoice_period/models/res_config_settings.py
+++ b/sale_order_partner_invoice_period/models/res_config_settings.py
@@ -12,7 +12,6 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     invoice_period_default = fields.Selection(
-        selection=INVOICE_PERIOD_SELECTION,
         related='company_id.invoice_period_default',
         help="Select default invoice period for new partners (Companies or Contacts).",
         readonly=False


### PR DESCRIPTION
Field invoice_period_default was related but also had selection attribute.
This caused a warning in res config settings. Removing selection attribute solves the issue.